### PR TITLE
fix: support null-prototype objects in markup props

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const isNode = (el) => {
 }
 
 const has = (object, key) => {
-	return object.hasOwnProperty(key)
+	return Object.prototype.hasOwnProperty.call(object, key)
 }
 
 const mapObject = (object, fn) => {

--- a/test/index.js
+++ b/test/index.js
@@ -128,6 +128,18 @@ test('Setting properties ignores prototype properties', (t) => {
 	t.is(checkbox.outerHTML, '<input name="yes" type="checkbox">')
 })
 
+test('Can set properties from objects without a prototype', (t) => {
+	const options = Object.create(null)
+	options.name = 'yes'
+	options.type = 'checkbox'
+
+	const checkbox = h('input', {
+		markup: [ options ]
+	})
+
+	t.is(checkbox.outerHTML, '<input name="yes" type="checkbox">')
+})
+
 test('Can register event handlers using element attributes', (t) => {
 	const onClick = spy()
 	const para = h('p', {


### PR DESCRIPTION
## Summary
- fix own-property detection to support null-prototype objects passed in markup config
- add regression coverage for `Object.create(null)` inputs

## Why
Hydroid currently assumes every object has `hasOwnProperty`. That crashes for null-prototype objects, which are valid dictionary-style objects and can reasonably be passed as prop bags.

## Testing
- `npm test`
  - 22 tests passed
